### PR TITLE
Ensure notebook outputs are striped

### DIFF
--- a/.github/workflows/ci-python-just.yml
+++ b/.github/workflows/ci-python-just.yml
@@ -34,6 +34,10 @@ jobs:
         run: just lint-md
       - name: Lint Python files
         run: just lint-python
+      - name: Ensure notebook outputs are striped
+        run: |
+          just notebook-strip
+          test -z "$(git status --porcelain)" || (git status; git diff; false)
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-python-just.yml
+++ b/.github/workflows/ci-python-just.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Setup the project
         run: just setup
       - run: echo $CONDA/envs/$CONDA_ENV/bin >> $GITHUB_PATH
+      - run: |
+          conda info
       - name: Lint markdown files
         run: just lint-md
       - name: Lint Python files

--- a/.github/workflows/ci-python-just.yml
+++ b/.github/workflows/ci-python-just.yml
@@ -21,17 +21,20 @@ jobs:
       - name: Cache conda
         uses: actions/cache@v2
         with:
-          path: ~/conda_pkgs_dir
+          path: |
+            /usr/share/miniconda/pkgs
+            /home/runner/.conda/pkgs
+            /usr/share/miniconda/envs
+            /home/runner/.conda/envs
           key:
-            ${{ runner.os }}-conda-${{ hashFiles('environment.yaml') }}
+            ${{ runner.os }}-conda-${{ hashFiles('environment.yaml') }}.0
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"
       - name: Setup the project
         run: just setup
       - run: echo $CONDA/envs/$CONDA_ENV/bin >> $GITHUB_PATH
-      - run: |
-          conda info
+      - run: conda info
       - name: Lint markdown files
         run: just lint-md
       - name: Lint Python files
@@ -49,9 +52,13 @@ jobs:
       - name: Cache conda
         uses: actions/cache@v2
         with:
-          path: ~/conda_pkgs_dir
+          path: |
+            /usr/share/miniconda/pkgs
+            /home/runner/.conda/pkgs
+            /usr/share/miniconda/envs
+            /home/runner/.conda/envs
           key:
-            ${{ runner.os }}-conda-${{ hashFiles('environment.yaml') }}
+            ${{ runner.os }}-conda-${{ hashFiles('environment.yaml') }}.0
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"

--- a/environment-macos-aarch64.yaml
+++ b/environment-macos-aarch64.yaml
@@ -156,6 +156,7 @@ dependencies:
   - nbclient=0.5.10=pyhd8ed1ab_1
   - nbconvert=6.4.1=py310hbe9552e_0
   - nbformat=5.1.3=pyhd8ed1ab_0
+  - nbstripout=0.5.0=pyhd8ed1ab_0
   - ncurses=6.3=hc470f4d_0
   - nest-asyncio=1.5.4=pyhd8ed1ab_0
   - networkx=2.6.3=pyhd8ed1ab_1

--- a/environment.yaml
+++ b/environment.yaml
@@ -23,4 +23,5 @@ dependencies:
   - pytest-mock
   - myst-parser
   - jupyterlab
+  - nbstripout
 prefix: /opt/homebrew/Caskroom/miniforge/base/envs/measure

--- a/justfile
+++ b/justfile
@@ -1,10 +1,9 @@
 src_dir := "measure"
 
-
 # Setup the environment.
 setup:
-    conda env create --file environment-{{os()}}-{{arch()}}.yaml \
-      || conda env update --file environment-{{os()}}-{{arch()}}.yaml \
+    conda env create --file environment-{{ os() }}-{{ arch() }}.yaml \
+      || conda env update --file environment-{{ os() }}-{{ arch() }}.yaml \
       || conda env create --file environment.yaml \
       || conda env update --file environment.yaml
 
@@ -21,10 +20,10 @@ lint-md:
 # Lint python files.
 lint-python:
     isort . --check
-    black --check {{src_dir}}
-    flake8 {{src_dir}}
-    pylint {{src_dir}}
-    pydocstyle {{src_dir}}
+    black --check {{ src_dir }}
+    flake8 {{ src_dir }}
+    pylint {{ src_dir }}
+    pydocstyle {{ src_dir }}
 
 # Meta tasks running all formatters at once.
 fmt: fmt-md fmt-python
@@ -36,13 +35,17 @@ fmt-md:
 # Format python files.
 fmt-python:
     isort .
-    black {{src_dir}}
+    black {{ src_dir }}
 
 # Save environment
 conda-export:
     conda env export --from-history > environment.yaml
-    conda env export > environment-{{os()}}-{{arch()}}.yaml
+    conda env export > environment-{{ os() }}-{{ arch() }}.yaml
 
 # Run the unit tests.
 test:
-  pytest -x --cov-report term-missing --cov-report html --cov={{src_dir}}
+    pytest -x --cov-report term-missing --cov-report html --cov={{ src_dir }}
+
+# Strip output from Jupyter notebooks.
+notebook-strip:
+    nbstripout notebooks/*.ipynb

--- a/notebooks/data_set_exploration.ipynb
+++ b/notebooks/data_set_exploration.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "ca618bc3-c9f2-472f-9781-97a61d0eefde",
    "metadata": {},
    "outputs": [],
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "48d5aced-8649-4d9a-b9b3-8e8da815d805",
    "metadata": {},
    "outputs": [],
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "dbc89323-7ada-465c-a7f7-0b475c39ad52",
    "metadata": {},
    "outputs": [],
@@ -33,61 +33,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "794fa4b9-f19a-40f9-9ac8-881016090276",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'geopandas.geodataframe.GeoDataFrame'>\n",
-      "RangeIndex: 96141 entries, 0 to 96140\n",
-      "Data columns (total 30 columns):\n",
-      " #   Column      Non-Null Count  Dtype   \n",
-      "---  ------      --------------  -----   \n",
-      " 0   ROAD_ID     96141 non-null  float64 \n",
-      " 1   NAME        78964 non-null  object  \n",
-      " 2   INTERSECTI  96141 non-null  float64 \n",
-      " 3   INTERSE_01  96141 non-null  float64 \n",
-      " 4   OSM_ID      96141 non-null  float64 \n",
-      " 5   TDG_ID      96141 non-null  object  \n",
-      " 6   FUNCTIONAL  96141 non-null  object  \n",
-      " 7   PATH_ID     9752 non-null   float64 \n",
-      " 8   SPEED_LIMI  12106 non-null  float64 \n",
-      " 9   ONE_WAY_CA  20771 non-null  object  \n",
-      " 10  ONE_WAY     20641 non-null  object  \n",
-      " 11  WIDTH_FT    639 non-null    float64 \n",
-      " 12  FT_BIKE_IN  8830 non-null   object  \n",
-      " 13  FT_BIKE_01  0 non-null      object  \n",
-      " 14  TF_BIKE_IN  5958 non-null   object  \n",
-      " 15  TF_BIKE_01  0 non-null      object  \n",
-      " 16  FT_LANES    17686 non-null  float64 \n",
-      " 17  TF_LANES    9105 non-null   float64 \n",
-      " 18  FT_CROSS_L  17648 non-null  float64 \n",
-      " 19  TF_CROSS_L  9097 non-null   float64 \n",
-      " 20  TWLTL_CROS  917 non-null    float64 \n",
-      " 21  FT_PARK     612 non-null    float64 \n",
-      " 22  TF_PARK     264 non-null    float64 \n",
-      " 23  FT_SEG_STR  96135 non-null  float64 \n",
-      " 24  FT_INT_STR  96141 non-null  int64   \n",
-      " 25  TF_SEG_STR  75506 non-null  float64 \n",
-      " 26  TF_INT_STR  96141 non-null  int64   \n",
-      " 27  XWALK       4252 non-null   float64 \n",
-      " 28  JOB_ID      96141 non-null  object  \n",
-      " 29  geometry    96141 non-null  geometry\n",
-      "dtypes: float64(17), geometry(1), int64(2), object(10)\n",
-      "memory usage: 22.0+ MB\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "raw_gdf.info()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "3536c605-41ad-49fb-af9b-6d98e5d05bf9",
    "metadata": {},
    "outputs": [],
@@ -98,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "f9162d20",
    "metadata": {},
    "outputs": [],
@@ -142,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "f2372be3-9828-4b5c-962d-855518b3b2d3",
    "metadata": {},
    "outputs": [],
@@ -153,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "4cf1422c-3670-40ab-a52e-6c452387d730",
    "metadata": {},
    "outputs": [],
@@ -164,81 +120,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "04be0bca-55f7-47fe-988c-cc4cc665d499",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>NAME</th>\n",
-       "      <th>FT_BIKE_IN</th>\n",
-       "      <th>TF_BIKE_IN</th>\n",
-       "      <th>geometry</th>\n",
-       "      <th>distance</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>State Highway 45 North</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>LINESTRING (615518.201 3371356.885, 615467.915...</td>\n",
-       "      <td>136.979923</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>LINESTRING (615527.803 3371236.027, 615482.016...</td>\n",
-       "      <td>134.169096</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                     NAME FT_BIKE_IN TF_BIKE_IN  \\\n",
-       "0  State Highway 45 North       None       None   \n",
-       "1                    None       None       None   \n",
-       "\n",
-       "                                            geometry    distance  \n",
-       "0  LINESTRING (615518.201 3371356.885, 615467.915...  136.979923  \n",
-       "1  LINESTRING (615527.803 3371236.027, 615482.016...  134.169096  "
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gdf.head(2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "6cc29609-e835-4e4f-a6b1-1534a4b3fd7f",
    "metadata": {},
    "outputs": [],
@@ -249,41 +141,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "2ef010fd-b1a2-48a1-a269-e12f7ef40559",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Derived Projected CRS: EPSG:32614>\n",
-       "Name: WGS 84 / UTM zone 14N\n",
-       "Axis Info [cartesian]:\n",
-       "- E[east]: Easting (metre)\n",
-       "- N[north]: Northing (metre)\n",
-       "Area of Use:\n",
-       "- name: Between 102°W and 96°W, northern hemisphere between equator and 84°N, onshore and offshore. Canada - Manitoba; Nunavut; Saskatchewan. Mexico. United States (USA).\n",
-       "- bounds: (-102.0, 0.0, -96.0, 84.0)\n",
-       "Coordinate Operation:\n",
-       "- name: UTM zone 14N\n",
-       "- method: Transverse Mercator\n",
-       "Datum: World Geodetic System 1984 ensemble\n",
-       "- Ellipsoid: WGS 84\n",
-       "- Prime Meridian: Greenwich"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gdf.crs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "7cf99d00-a76b-46cf-9e66-6b015793870a",
    "metadata": {},
    "outputs": [],
@@ -294,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "ad1f780b-6904-4fe4-9339-4c78134c2d2b",
    "metadata": {},
    "outputs": [],
@@ -308,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "33a17a26-fa94-4f80-b993-249ffd9da3d5",
    "metadata": {},
    "outputs": [],
@@ -319,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "cde0076e-90d7-4a25-8763-d7a797f2dc11",
    "metadata": {},
    "outputs": [],
@@ -330,197 +198,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "d01dfa16-1c7b-4908-8e62-eaf2a94b4a5e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>distance</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>FT_BIKE_IN</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>buffered_lane</th>\n",
-       "      <td>91.830</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>lane</th>\n",
-       "      <td>430.763</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>sharrow</th>\n",
-       "      <td>74.032</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>track</th>\n",
-       "      <td>14.939</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>NaN</th>\n",
-       "      <td>8673.986</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "               distance\n",
-       "FT_BIKE_IN             \n",
-       "buffered_lane    91.830\n",
-       "lane            430.763\n",
-       "sharrow          74.032\n",
-       "track            14.939\n",
-       "NaN            8673.986"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "grouped"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "dfabfd68-2abf-49c9-95a7-019c4fe45bec",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "9285.552048446249"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gdf[\"distance\"].sum() / 1000"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "0ced426c-4b43-4dc5-a489-9964e38967cc",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'distance': {'buffered_lane': 91.83,\n",
-       "  'lane': 430.763,\n",
-       "  'sharrow': 74.032,\n",
-       "  'track': 14.939,\n",
-       "  nan: 8673.986}}"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "grouped.to_dict()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "f418ae93-6e5f-4fe6-ac89-964a2de52974",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'index': ['buffered_lane', 'lane', 'sharrow', 'track', nan],\n",
-       " 'columns': ['distance'],\n",
-       " 'data': [[91.83], [430.763], [74.032], [14.939], [8673.986]]}"
-      ]
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "grouped.to_dict('split')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "91ff2518-3976-4ee3-ae40-17c20ae1748c",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'distance': 91.83},\n",
-       " {'distance': 430.763},\n",
-       " {'distance': 74.032},\n",
-       " {'distance': 14.939},\n",
-       " {'distance': 8673.986}]"
-      ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "grouped.to_dict('records')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "8672895b-ad83-4b2c-a39d-ae57f008f011",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'buffered_lane': {'distance': 91.83},\n",
-       " 'lane': {'distance': 430.763},\n",
-       " 'sharrow': {'distance': 74.032},\n",
-       " 'track': {'distance': 14.939},\n",
-       " nan: {'distance': 8673.986}}"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "grouped_dict = grouped.to_dict('index')\n",
     "grouped_dict"
@@ -528,79 +259,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "b07bf07a-3fd8-4092-99ea-47dece1bfab2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>FT_BIKE_IN</th>\n",
-       "      <th>distance</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>buffered_lane</td>\n",
-       "      <td>9.183023e+04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>lane</td>\n",
-       "      <td>4.307633e+05</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>sharrow</td>\n",
-       "      <td>7.403230e+04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>track</td>\n",
-       "      <td>1.493962e+04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>NaN</td>\n",
-       "      <td>8.673987e+06</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "      FT_BIKE_IN      distance\n",
-       "0  buffered_lane  9.183023e+04\n",
-       "1           lane  4.307633e+05\n",
-       "2        sharrow  7.403230e+04\n",
-       "3          track  1.493962e+04\n",
-       "4            NaN  8.673987e+06"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "regrouped = gdf.groupby(\"FT_BIKE_IN\",dropna=False, as_index=False).sum()\n",
     "regrouped"
@@ -608,25 +270,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "d7b650ab-a1d3-4687-81bd-c4d84cddacd6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[{'FT_BIKE_IN': 'buffered_lane', 'distance': 91830.23366920228},\n",
-       " {'FT_BIKE_IN': 'lane', 'distance': 430763.2828821904},\n",
-       " {'FT_BIKE_IN': 'sharrow', 'distance': 74032.30287448216},\n",
-       " {'FT_BIKE_IN': 'track', 'distance': 14939.622807880232},\n",
-       " {'FT_BIKE_IN': nan, 'distance': 8673986.606212495}]"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "regrouped_d = regrouped.to_dict(\"records\")\n",
     "regrouped_d"


### PR DESCRIPTION
Updates the CI workflow and `justfile` to add tasks to ensure the
outputs of the Jupyter notebooks are not saved.
